### PR TITLE
Fix: ENTITY GenerationType 수정

### DIFF
--- a/src/main/java/team/hanaro/hanamate/entities/Account.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Account.java
@@ -4,9 +4,11 @@ import lombok.*;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Table;
 import java.sql.Timestamp;
 
 @Entity
+@Table(name = "accounts")
 @Getter
 @ToString
 @AllArgsConstructor

--- a/src/main/java/team/hanaro/hanamate/entities/Account.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Account.java
@@ -4,11 +4,9 @@ import lombok.*;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.Table;
 import java.sql.Timestamp;
 
 @Entity
-@Table(name = "allowance_history")
 @Getter
 @ToString
 @AllArgsConstructor

--- a/src/main/java/team/hanaro/hanamate/entities/Account.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Account.java
@@ -14,7 +14,7 @@ import java.sql.Timestamp;
 @Builder
 public class Account {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long accountId;
 
     private Long memberId;

--- a/src/main/java/team/hanaro/hanamate/entities/Account.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Account.java
@@ -16,9 +16,9 @@ import java.sql.Timestamp;
 @Builder
 public class Account {
     @Id
-    private Long accountId;
-
     private Long memberId;
+
+    private Long accountId;
     private String name;
     private Timestamp openDate;
     private Integer balance;

--- a/src/main/java/team/hanaro/hanamate/entities/Account.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Account.java
@@ -2,7 +2,9 @@ package team.hanaro.hanamate.entities;
 
 import lombok.*;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.sql.Timestamp;
 
 @Entity
@@ -14,7 +16,6 @@ import java.sql.Timestamp;
 @Builder
 public class Account {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long accountId;
 
     private Long memberId;

--- a/src/main/java/team/hanaro/hanamate/entities/AllowanceHistory.java
+++ b/src/main/java/team/hanaro/hanamate/entities/AllowanceHistory.java
@@ -14,7 +14,7 @@ import java.sql.Timestamp;
 @Builder
 public class AllowanceHistory {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long historyId;
     private Long allowanceId;
     private Integer allowanceAmount;

--- a/src/main/java/team/hanaro/hanamate/entities/Allowances.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Allowances.java
@@ -13,7 +13,7 @@ import javax.persistence.*;
 @Builder
 public class Allowances {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long allowanceId;
 
     private Long parentId;

--- a/src/main/java/team/hanaro/hanamate/entities/Article.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Article.java
@@ -14,7 +14,7 @@ import java.sql.Timestamp;
 @Builder
 public class Article {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long articleId;
 
     private Long walletId;

--- a/src/main/java/team/hanaro/hanamate/entities/Comments.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Comments.java
@@ -14,7 +14,7 @@ import java.sql.Timestamp;
 @Builder
 public class Comments {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
 
     private Long articleId;

--- a/src/main/java/team/hanaro/hanamate/entities/Images.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Images.java
@@ -16,7 +16,7 @@ import java.sql.Timestamp;
 public class Images {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long imageId;
     private String fileName;
     private Integer fileSize;

--- a/src/main/java/team/hanaro/hanamate/entities/LoanHistory.java
+++ b/src/main/java/team/hanaro/hanamate/entities/LoanHistory.java
@@ -14,7 +14,7 @@ import java.sql.Timestamp;
 @Builder
 public class LoanHistory {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long historyId;
     private Long allowanceId;
     private Integer allowanceAmount;

--- a/src/main/java/team/hanaro/hanamate/entities/Loans.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Loans.java
@@ -14,7 +14,7 @@ import java.sql.Timestamp;
 @Builder
 public class Loans {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long loanId;
 
     private Long childrenId;

--- a/src/main/java/team/hanaro/hanamate/entities/Member.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Member.java
@@ -14,7 +14,7 @@ import java.sql.Timestamp;
 @Builder
 public class Member {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
 
     private Long walletId; /* 개인 지갑 Id */

--- a/src/main/java/team/hanaro/hanamate/entities/Requests.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Requests.java
@@ -14,7 +14,7 @@ import java.sql.Timestamp;
 @Builder
 public class Requests {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long requestId;
 
     private Long targetId;

--- a/src/main/java/team/hanaro/hanamate/entities/Savings.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Savings.java
@@ -14,7 +14,7 @@ import java.sql.Timestamp;
 @Builder
 public class Savings {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long savingsId;
 
     private Long childrenId;

--- a/src/main/java/team/hanaro/hanamate/entities/SavingsHistory.java
+++ b/src/main/java/team/hanaro/hanamate/entities/SavingsHistory.java
@@ -14,7 +14,7 @@ import java.sql.Timestamp;
 @Builder
 public class SavingsHistory {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long historyId;
     private Long savingsId;
     private Integer sequence;

--- a/src/main/java/team/hanaro/hanamate/entities/Transactions.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Transactions.java
@@ -14,7 +14,7 @@ import java.sql.Timestamp;
 @Builder
 public class Transactions {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "transaction_id")
     private Long id;
 

--- a/src/main/java/team/hanaro/hanamate/entities/Transactions.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Transactions.java
@@ -20,10 +20,10 @@ public class Transactions {
 
     private Long walletId;
     private Long counterId;
-    private Timestamp date;
-    private String type;
+    private Timestamp transactionDate;
+    private String transactionType;
     private Integer amount;
     private String location;
     private Integer balance;
-    private Boolean status;
+    private Boolean success;
 }

--- a/src/main/java/team/hanaro/hanamate/entities/Wallets.java
+++ b/src/main/java/team/hanaro/hanamate/entities/Wallets.java
@@ -13,7 +13,7 @@ import javax.persistence.*;
 @Builder
 public class Wallets {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long walletId;
     private Boolean walletType; /* 0: 개인, 1: 모임통장 */
     private Long balance;


### PR DESCRIPTION
### 코드 작성 이유
1. GenerationType.AUTO를 GenerationType.IDENTITY로 변경했습니다.
2. DB 예약어인 필드(date, type)를 수정했습니다.
3. Account Entity 수정
<br>

### 상세 사항
- Hibernate 5.0부터 MySQL의 GenerationType.AUTO의 기본 생성전략은 IDENTITY가 아닌 TABLE을 기본 시퀀스 전략으로 선택
<br />
이를 해결하기 위한 방법으로는, 

1. application.properties/yml의 use-new-id-generator-mappings을 false로 설정한다.
2. @GeneratedValue의 전략을 GenerationType.IDENTITY로 지정한다.
<br />
저는 GenerationType을 IDENTITY로 수정했습니다
<br>

### 참고 사항
https://jojoldu.tistory.com/295
<br>

#### CheckList

- [x] MVC 패턴 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
