### PR TITLE
Fix: 지갑to지갑 이체, 거래내역 조회 Dto 수정

### DIFF
--- a/src/main/java/team/hanaro/hanamate/domain/MyWallet/Dto/RequestDto.java
+++ b/src/main/java/team/hanaro/hanamate/domain/MyWallet/Dto/RequestDto.java
@@ -1,6 +1,6 @@
 package team.hanaro.hanamate.domain.MyWallet.Dto;
 
-import lombok.*;
+import lombok.Data;
 import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.NotBlank;
@@ -31,6 +31,8 @@ public class RequestDto {
         private Long receiveWalletId;
         @Positive(message = "요청 금액은 1이상의 양수 값을 입력해주세요.")
         private Integer amount;
+        @Nullable
+        private String message;
     }
 
 }

--- a/src/main/java/team/hanaro/hanamate/domain/MyWallet/Dto/ResponseDto.java
+++ b/src/main/java/team/hanaro/hanamate/domain/MyWallet/Dto/ResponseDto.java
@@ -46,6 +46,7 @@ public class ResponseDto {
         private Integer amount;
         private Integer balance;
         private String type;
+        private String message;
 
         public MyTransactions(Transactions transactions) {
             id = transactions.getId();
@@ -54,6 +55,7 @@ public class ResponseDto {
             amount = transactions.getAmount();
             balance = transactions.getBalance();
             type = transactions.getTransactionType();
+            message = transactions.getMessage();
         }
     }
 

--- a/src/main/java/team/hanaro/hanamate/domain/User/Repository/UsersRepository.java
+++ b/src/main/java/team/hanaro/hanamate/domain/User/Repository/UsersRepository.java
@@ -1,17 +1,19 @@
 package team.hanaro.hanamate.domain.User.Repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import team.hanaro.hanamate.entities.MyWallet;
 import team.hanaro.hanamate.entities.User;
 
 import java.util.Optional;
 
 public interface UsersRepository extends JpaRepository<User, Long> {
-//    Optional<Users> findByEmail(String email);
+    //    Optional<Users> findByEmail(String email);
     Optional<User> findByLoginId(String id);
 
-//    boolean existsByEmail(String email);
+    //    boolean existsByEmail(String email);
     boolean existsByLoginId(String id);
 
     Optional<User> findUserByPhoneNumber(String phoneNumber);
 
+    Optional<User> findByMyWallet(MyWallet wallet);
 }


### PR DESCRIPTION
### 코드 작성 이유
1. 지갑to지갑 이체 시 requestDto에 message 추가  (Nullable)
2. 거래내역 조회 시 message 추가
<br>

### 상세 사항
message가 있으면,
보내는 사람 거래내역 : message
받는 사람 거래내역 : message

message가 없으면
보내는 사람 거래내역 : 받는 사람 이름
받는 사람 거래내역 : 보내는 사람 이름
<br>

### 참고 사항

<br>

#### CheckList

- [x] MVC 패턴 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
